### PR TITLE
Propogate Bluetooth DT changes to other elsa variants

### DIFF
--- a/arch/arm64/boot/dts/lge/msm8996-elsa_clr_pr/msm8996-elsa_clr_pr-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_clr_pr/msm8996-elsa_clr_pr-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_cno_cn/msm8996-elsa_cno_cn-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_cno_cn/msm8996-elsa_cno_cn-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_dcm/msm8996-elsa_dcm_jp-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_dcm/msm8996-elsa_dcm_jp-pinctrl.dtsi
@@ -146,6 +146,7 @@
 		};
 */
 //[ANNA_ISDBT_BRINGUP_E]
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -161,6 +162,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_global_ca/msm8996-elsa_global_ca-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_global_ca/msm8996-elsa_global_ca-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_global_com/msm8996-elsa_global_com-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_global_com/msm8996-elsa_global_com-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_global_livedummy/msm8996-elsa_global_livedummy-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_global_livedummy/msm8996-elsa_global_livedummy-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_kddi/msm8996-elsa_kddi_jp-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_kddi/msm8996-elsa_kddi_jp-pinctrl.dtsi
@@ -146,6 +146,7 @@
 		};
 */
 //[ANNA_ISDBT_BRINGUP_E]
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -161,6 +162,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_kr/msm8996-elsa_kr-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_kr/msm8996-elsa_kr-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_spi_tdmb {

--- a/arch/arm64/boot/dts/lge/msm8996-elsa_usc_us/msm8996-elsa_usc_us-pinctrl.dtsi
+++ b/arch/arm64/boot/dts/lge/msm8996-elsa_usc_us/msm8996-elsa_usc_us-pinctrl.dtsi
@@ -141,6 +141,7 @@
 				};
 			};
 		};
+#if IS_ENABLED(CONFIG_LINE_DISCIPLINE_DRIVER)
 		/* gpio pin mux for bluetooth host wake pin */
 		pmx_bt_default {
 			bt_default: bt_default {
@@ -156,6 +157,7 @@
 				};
 			};
 		};
+#endif
 //[H1_BT_BRINGUP_E]
 
 		pmx_mdss: pmx_mdss {


### PR DESCRIPTION
Other versions of the V20/elsa also need the device-tree changes for
Bluetooth.  Since these can be disabled while leaving breadcrumbs behind
for others, do so.  While LineageOS has no plans for support of LGE's
Bluetooth driver, staying out of the way of people who wish to have it
is very helpful to those individuals.

Change-Id: I32651e69ea8b8b4ce654375f075ec65cc5d2d38b